### PR TITLE
fix: theme color default fallbacks

### DIFF
--- a/app/Http/Controllers/AdminSettingsController.php
+++ b/app/Http/Controllers/AdminSettingsController.php
@@ -144,8 +144,31 @@ class AdminSettingsController extends Controller
 
         /* @var Setting $setting */
         if (! empty($setting = Setting::find($request->setting_id))) {
+            $defaultValue = function (string $setting): ?string {
+                switch ($setting) {
+                    case 'theme.primary':
+                        return '#040E29';
+                    case 'theme.white':
+                        return '#FFFFFF';
+                    case 'theme.gray':
+                        return '#F3F9FC';
+                    case 'theme.success':
+                        return '#0F7038';
+                    case 'theme.warning':
+                        return '#FFD500';
+                    case 'theme.danger':
+                        return '#B21E35';
+                    case 'theme.info':
+                        return '#1464F6';
+                    case 'theme.body':
+                        return '#3C4858';
+                    default:
+                        return null;
+                }
+            };
+
             $setting->update([
-                'value' => $request->value ? $request->value : null,
+                'value' => $request->value ? $request->value : $defaultValue($setting->setting),
             ]);
 
             $tenant   = request()->tenant;
@@ -155,10 +178,13 @@ class AdminSettingsController extends Controller
             if (
                 collect([
                     'theme.primary',
-                    'theme.secondary',
-                    'theme.secondary-dark',
                     'theme.white',
                     'theme.gray',
+                    'theme.success',
+                    'theme.warning',
+                    'theme.danger',
+                    'theme.info',
+                    'theme.body',
                 ])->contains($setting->setting)
             ) {
                 $tenant   = request()->tenant;


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief description of the changes in this PR -->
Setting a color to `null` would have broken the entire application with the old implementation. Thus, fallbacks with OBMS brand colors have been implemented which will override null-values if they are being set through the settings update form.

## Type of Change
<!-- Select the type of change this PR introduces -->
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] docs: Documentation only changes
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] perf: A code change that improves performance
- [ ] test: Adding missing tests or correcting existing tests
- [ ] chore: Changes to the build process or auxiliary tools and libraries
- [ ] ci: Changes to our CI configuration files and scripts

## Breaking Changes
<!-- Does this PR introduce any breaking changes? -->
- [ ] Yes
- [x] No

<!-- If yes, please describe the breaking changes -->

## Related Issues
<!-- Link any related issues here using the format: Fixes #123, Closes #456 -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have read and agree to the [Contributing Guidelines](https://github.com/forepath/obms/blob/main/CONTRIBUTING.md)

## Additional Notes
<!-- Add any additional notes about the PR here --> 
